### PR TITLE
Changing argument name

### DIFF
--- a/defaults/config.yaml
+++ b/defaults/config.yaml
@@ -13,6 +13,6 @@ datasets:
   clade_min_seq: 100
   pivot: "12"
   generation_time: 2.0
-  temporal_aggregation: '2W'
+  aggregation_frequency: '2W'
 
 mlr_config: "defaults/mlr-config.yaml"

--- a/rules/mlr_estimates.smk
+++ b/rules/mlr_estimates.smk
@@ -42,7 +42,7 @@ rule mlr_model:
         export_path = lambda w: f"mlr-estimates/{w.dataset}",
         pivot = lambda wildcards: _get_models_option(wildcards, 'pivot'),
         generation_time = lambda wildcards: _get_models_option(wildcards, 'generation_time'),
-        temporal_aggregation = lambda wildcards: _get_models_option(wildcards, 'temporal_aggregation')
+        aggregation_frequency = lambda wildcards: _get_models_option(wildcards, 'aggregation_frequency')
     resources:
         mem_mb=4000
     shell:
@@ -53,6 +53,6 @@ rule mlr_model:
             --export-path {params.export_path} \
             {params.pivot} \
             {params.generation_time} \
-	    {params.temporal_aggregation} \
+	    {params.aggregation_frequency} \
             --data-name mlr 2>&1 | tee {log}
         """

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -147,7 +147,7 @@ def fit_models(
     path,
     save,
     pivot=None,
-    temporal_aggregation=None,
+    aggregation_frequency=None,
 ):
     multi_posterior = ef.MultiPosterior()
 
@@ -158,7 +158,7 @@ def fit_models(
             raw_seq=raw_seq,
             pivot=pivot,
             group="location",
-            temporal_aggregation=temporal_aggregation,
+            aggregation_frequency=aggregation_frequency,
         )
 
         # Fit model
@@ -179,7 +179,7 @@ def fit_models(
                 continue
 
             data = ef.VariantFrequencies(
-                raw_seq=raw_seq, pivot=pivot, temporal_aggregation=temporal_aggregation
+                raw_seq=raw_seq, pivot=pivot, aggregation_frequency=aggregation_frequency
             )
 
             # Fit model
@@ -380,7 +380,7 @@ if __name__ == "__main__":
         help="Generation time to use. Overrides model.generation_time in config.",
     )
     parser.add_argument(
-        "--temporal-aggregation",
+        "--aggregation-frequency",
         type=str,
         help="Frequency at which to aggregate temporally. Overrides model.temporal-aggregation in config.",
     )
@@ -392,6 +392,7 @@ if __name__ == "__main__":
         + "Default is false if unspecified.",
     )
     args = parser.parse_args()
+    print(ef.__version__)
 
     # Load configuration, data, and create model
     config = MLRConfig(args.config)
@@ -438,9 +439,9 @@ if __name__ == "__main__":
 
     # Decide level of temporal aggregation
     # Use mlr config
-    temporal_aggregation = None
-    if args.temporal_aggregation:
-        temporal_aggregation = args.generation_time
+    aggregation_frequency = None
+    if args.aggregation_frequency:
+        aggregation_frequency = args.generation_time
 
     # Fit or load model results
     if fit:
@@ -454,7 +455,7 @@ if __name__ == "__main__":
             export_path,
             save,
             pivot=pivot,
-            temporal_aggregation=args.temporal_aggregation,
+            aggregation_frequency=args.aggregation_frequency,
         )
     elif load:
         print("Loading results")


### PR DESCRIPTION
Okay I figured out how to build the updated docker-base image in the meantime. I ran:

```
git clone https://github.com/nextstrain/docker-base.git`
cd docker-base
make

```

This creates `localhost:5000/nextstrain/base:latest` which we can use with `nextstrain build` to run the workflow with the newest `evofr` version
```
nextstrain build - -image llocalhost:5000/nextstrain/base:latest . -j 1 all
```

This made me find a bug that should be fixed here.